### PR TITLE
Fixing a few typos - Tuples section and README link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ for more detailed instructions.
 1. [Rc and raw pointers](rc%20raw.md)
 1. [Data types](data%20types.md)
 1. [Destructuring pt 1](destructuring.md)
-1. [Destructuring pt 2](destructuring2.md)
+1. [Destructuring pt 2](destructuring 2.md)
 1. [Arrays and vecs](arrays.md)
 1. [Graphs and arena allocation](graphs/README.md)
 

--- a/data types.md
+++ b/data types.md
@@ -86,8 +86,8 @@ fn foo() {
 Tuples are anonymous, heterogeneous sequences of data. As a type, they are
 declared as a sequence of types in parentheses. Since there is no name, they are
 identified by structure. For example, the type `(int, int)` is a pair of
-integers and `(i32, f32, S)` is a triple. Enum values are initialised in the
-same way as enum types are declared, but with values instead of types for the
+integers and `(i32, f32, S)` is a triple. Tuple values are initialised in the
+same way as tuple types are declared, but with values instead of types for the
 components, e.g., `(4, 5)`. An example:
 
 ```rust


### PR DESCRIPTION
These articles are great, thanks! I noticed a few minor things while going through them:

 * In the _Tuples_ section in the _Data Types_ article, the text referenced Enum initialization where I think it meant Tuple initialization.
 * The README link to the _Destructuring pt 2_ article was broken.