### PR TITLE
Improve how the list of operators are presented in Primitives chapter

### DIFF
--- a/primitives.md
+++ b/primitives.md
@@ -70,10 +70,12 @@ fn main() {
 
 Rust has the following operators:
 
-*Numeric:* `+`, `-`, `*`, `/`, `%`\
-*Bitwise:* `|`, `&`, `^`, `<<`, `>>`\
-*Comparison:* `==`, `!=`, `>`, `<`, `>=`, `<=`\
-*Short-circuit logical:* `||`, `&&`
+|         Type          |            Operators             |
+| --------------------- | -------------------------------- |
+| Numeric               | `+`, `-`, `*`, `/`, `%`          |
+| Bitwise               | `\|`, `&`, `^`, `<<`, `>>`       |
+| Comparison            | `==`, `!=`, `>`, `<`, `>=`, `<=` |
+| Short-circuit logical | `\|\|`, `&&`                     |
 
 All of these behave as in C++, however, Rust is a bit stricter about the types
 the operators can be applied to - the bitwise operators can only be applied to

--- a/primitives.md
+++ b/primitives.md
@@ -70,10 +70,10 @@ fn main() {
 
 Rust has the following operators:
 
-Numeric: `+`, `-`, `*`, `/`, `%`\
-Bitwise: `|`, `&`, `^`, `<<`, `>>`\
-Comparison: `==`, `!=`, `>`, `<`, `>=`, `<=`\
-Short-circuit logical: `||`, `&&`
+*Numeric:* `+`, `-`, `*`, `/`, `%`\
+*Bitwise:* `|`, `&`, `^`, `<<`, `>>`\
+*Comparison:* `==`, `!=`, `>`, `<`, `>=`, `<=`\
+*Short-circuit logical:* `||`, `&&`
 
 All of these behave as in C++, however, Rust is a bit stricter about the types
 the operators can be applied to - the bitwise operators can only be applied to

--- a/primitives.md
+++ b/primitives.md
@@ -68,13 +68,17 @@ fn main() {
 }
 ```
 
-Rust has the following numeric operators: `+`, `-`, `*`, `/`, `%`; bitwise
-operators: `|`, `&`, `^`, `<<`, `>>`; comparison operators: `==`, `!=`, `>`,
-`<`, `>=`, `<=`; short-circuit logical operators: `||`, `&&`. All of these
-behave as in C++, however, Rust is a bit stricter about the types the operators
-can be applied to - the bitwise operators can only be applied to integers and
-the logical operators can only be applied to booleans. Rust has the `-` unary
-operator which negates a number. The `!` operator negates a boolean and inverts
-every bit on an integer type (equivalent to `~` in C++ in the latter case). Rust
-has compound assignment operators as in C++, e.g., `+=`, but does not have
-increment or decrement operators (e.g., `++`).
+Rust has the following operators:
+
+Numeric: `+`, `-`, `*`, `/`, `%`\
+Bitwise: `|`, `&`, `^`, `<<`, `>>`\
+Comparison: `==`, `!=`, `>`, `<`, `>=`, `<=`\
+Short-circuit logical: `||`, `&&`
+
+All of these behave as in C++, however, Rust is a bit stricter about the types
+the operators can be applied to - the bitwise operators can only be applied to
+integers and the logical operators can only be applied to booleans. Rust has the
+`-` unary operator which negates a number. The `!` operator negates a boolean
+and inverts every bit on an integer type (equivalent to `~` in C++ in the latter
+case). Rust has compound assignment operators as in C++, e.g., `+=`, but does
+not have increment or decrement operators (e.g., `++`).


### PR DESCRIPTION
I was reading this book on from my phone and it was difficult to scan through the list of operators. Using a table is just a suggestion but even if they were organized using a list it would be much easier to read on any device.