### PR TITLE
Update README to remove dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ catered for.
   out of date in places, but thorough; good for looking up details.
 * [Discuss forum](http://users.rust-lang.org/) - general forum for discussion or
   questions about using and learning Rust.
-* [#rust irc channel](https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust) - probably
-  the best place to get quick answers to your Rust questions if you like irc.
 * [StackOverflow Rust questions](https://stackoverflow.com/questions/tagged/rust) - answers
   to many beginner and advanced questions about Rust, but be careful though - Rust
   has changed *a lot* over the years and some of the answers might be very out of date.


### PR DESCRIPTION
As of March 2020, Mozilla has decommissioned its IRC network (see the [wiki](https://wiki.mozilla.org/IRC)), so the link to it is dead. It appears that the replacement is a Matrix server, although I cannot verify whether or not there is currently a Rust channel there.

(Great resource, by the way.)