### PR TITLE
correct std::make_unique() function call

### DIFF
--- a/unique.md
+++ b/unique.md
@@ -193,4 +193,4 @@ Differences:
 
 `let x = Box::new(75)` in Rust may be interpreted as `const auto x =
 std::unique_ptr<const int>{new int{75}};` in C++11 and `const auto x =
-std::make_unique<const int>{75};` in C++14.
+std::make_unique<const int>(75);` in C++14.


### PR DESCRIPTION
Since std::make_unique() is a free function, the parameters should be inside parenthesis unlike std::unique_ptr<T> which is a type and curly braces is used to call it's constructor.