### PR TITLE
The captured values are moved when the closure is called, not when it's constructed

### DIFF
--- a/closures.md
+++ b/closures.md
@@ -402,7 +402,8 @@ by the compiler, no annotation is necessary). If a variable is moved into a
 closure, i.e., it is captured by value (either because of an explicit `move` or
 due to inference), then the closure will have a `FnOnce` type. It would be unsafe
 to call such a closure multiple times because the captured variable would be
-moved more than once.
+moved more than once; this is because the moving happens at the time the closure
+is called, not at the time the closure is constructed.
 
 Rust will do its best to infer the most flexible type for the closure if it can.
 


### PR DESCRIPTION
_WARNING_ I'm a n00b to Rust, so this is likely incorrect! Please review carefully, and apologies if this is incorrect 😀.

While closures can capture some environment by moving, it's not entirely clear to me _when_ this happens. I guess it happens when the closure is called, not when the closure is created.

Hence, I'm proposing to add a few words. I don't think this is made entirely clear elsewhere in the document.