### PR TITLE
Without the use of y, the code would compile and run successfully.

### DIFF
--- a/borrowed.md
+++ b/borrowed.md
@@ -117,6 +117,7 @@ fn foo() {
     {
         let y = &x;           // type: &i32
         //x = 4;              // Error - x has been borrowed
+        //println!("{}", y);  // Use of borrowed value
         println!("{}", x);    // Ok - x can be read
     }
     x = 4;                    // OK - y no longer exists
@@ -135,6 +136,7 @@ fn foo() {
     {
         let y = &mut x;       // type: &mut i32
         //x = 4;              // Error - x has been borrowed
+        //println!("{}", y);  // Use of borrowed value
         //println!("{}", x);  // Error - requires borrowing x
     }
     x = 4;                    // OK - y no longer exists


### PR DESCRIPTION
As of Rust 1.60, the edited examples would compile successfully. This would be irritating for newcomers, as they would expect an error during compilation. Printing the value of the reference y forces the compiler to make an error.