### PR TITLE
Add missing file to pdf script

### DIFF
--- a/compile_pdf.sh
+++ b/compile_pdf.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-pandoc -s README.md hello-world.md control-flow.md primitives.md unique.md borrowed.md rc-raw.md destructuring.md destructuring-2.md arrays.md graphs/README.md closures.md -o r4cppp.pdf
+pandoc -s README.md hello-world.md control-flow.md primitives.md unique.md borrowed.md data-types.md rc-raw.md destructuring.md destructuring-2.md arrays.md graphs/README.md closures.md -o r4cppp.pdf


### PR DESCRIPTION
Adds `data-types.md` to pdf script, which is present in `README.md` but missing from the script.