### PR TITLE
Fixed logical error

### DIFF
--- a/borrowed.md
+++ b/borrowed.md
@@ -117,7 +117,7 @@ fn foo() {
     {
         let y = &x;           // type: &i32
         //x = 4;              // Error - x has been borrowed
-        println!("{}", x);    // Ok - x can be read
+        println!("{} {}", y, x);    // Ok - x can be read
     }
     x = 4;                    // OK - y no longer exists
 }


### PR DESCRIPTION
We should use 'y' somewhere, if we don't use it, x = 4; is perfectly fine code here and can be compiled without any error