### PR TITLE
use typed-arena crate

### DIFF
--- a/graphs/Cargo.toml
+++ b/graphs/Cargo.toml
@@ -3,6 +3,9 @@ name = "graphs"
 version = "0.0.1"
 authors = ["nrc <ncameron@mozilla.com>"]
 
+[dependencies]
+typed-arena = "*"
+
 [[bin]]
 name = "graphs"
 path = "src/mod.rs"

--- a/graphs/Cargo.toml
+++ b/graphs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = ["nrc <ncameron@mozilla.com>"]
 
 [dependencies]
-typed-arena = "*"
+typed-arena = "2"
 
 [[bin]]
 name = "graphs"

--- a/graphs/src/mod.rs
+++ b/graphs/src/mod.rs
@@ -1,6 +1,6 @@
 #![feature(rustc_private)]
 
-extern crate arena;
+extern crate typed_arena;
 
 mod rc_graph;
 mod ref_graph;

--- a/graphs/src/ref_graph.rs
+++ b/graphs/src/ref_graph.rs
@@ -1,7 +1,7 @@
 
 use std::cell::UnsafeCell;
 use std::collections::HashSet;
-use arena::TypedArena;
+use typed_arena::Arena;
 
 struct Node<'a> {
     datum: &'static str,
@@ -9,7 +9,7 @@ struct Node<'a> {
 }
 
 impl<'a> Node<'a> {
-    fn new<'b>(datum: &'static str, arena: &'b TypedArena<Node<'b>>) -> &'b Node<'b> {
+    fn new<'b>(datum: &'static str, arena: &'b Arena<Node<'b>>) -> &'b Node<'b> {
         arena.alloc(Node {
             datum: datum,
             edges: UnsafeCell::new(Vec::new()),
@@ -42,7 +42,7 @@ fn foo<'a>(node: &'a Node<'a>) {
     println!("foo: {}", node.datum);
 }
 
-fn init<'a>(arena: &'a TypedArena<Node<'a>>) ->&'a Node<'a> {
+fn init<'a>(arena: &'a Arena<Node<'a>>) ->&'a Node<'a> {
     let root = Node::new("A", arena);
 
     let b = Node::new("B", arena);
@@ -65,7 +65,7 @@ fn init<'a>(arena: &'a TypedArena<Node<'a>>) ->&'a Node<'a> {
 }
 
 pub fn main() {
-    let arena = TypedArena::new();
+    let arena = Arena::new();
     let g = init(&arena);
     g.traverse(&|d| println!("{}", d), &mut HashSet::new());
     foo(g.first());


### PR DESCRIPTION
Currently, the `graphs` directory doesn't build:

``` $ cargo build
   Compiling graphs v0.0.1 (/home/synec/prog/r4cppp/graphs)
error[E0463]: can't find crate for `arena`
 --> src/mod.rs:3:1
  |
3 | extern crate arena;
  | ^^^^^^^^^^^^^^^^^^^ can't find crate

For more information about this error, try `rustc --explain E0463`.
error: could not compile `graphs` (bin "graphs") due to previous error
```

Apparently the `libarena` crate has been moved since this was first written. I changed this to use the `typed-arena` crate from crates.rs, and it seems to work with a bit of refactoring.