### PR TITLE
data-types: fix explanation for struct cannot contain itself

### DIFF
--- a/data-types.md
+++ b/data-types.md
@@ -66,7 +66,7 @@ struct R {
 }
 ```
 
-If we didn't have the `Option` in the above struct, there would be no way to
+If we didn't have the `Box` in the above struct, there would be no way to
 instantiate the struct and Rust would signal an error.
 
 Structs with no fields do not use braces in either their definition or literal


### PR DESCRIPTION
The Box, not the Option, is what makes this able to work since the Box is the pointer indirection needed to make the memory layout of the struct well-defined